### PR TITLE
[#19]: support rel=canonical url

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -35,7 +35,9 @@ likely.initiate = likely.initate = function () {
     var widgets = dom.findAll('.' + config.name);
 
     utils.toArray(widgets)
-        .forEach(likely);
+        .forEach(function (widget) {
+            likely(widget);
+        });
 };
 
 /**

--- a/source/index.js
+++ b/source/index.js
@@ -47,7 +47,7 @@ likely.defaults = {
     zeroes: false,
     title: document.title,
     wait: 0.5e3,
-    url: window.location.href.replace(window.location.hash, ''),
+    url: utils.getDefaultUrl(),
 };
 
 module.exports = likely;

--- a/source/utils.js
+++ b/source/utils.js
@@ -199,6 +199,22 @@ var utils = {
 
         object[last] = value;
     },
+
+    /**
+     * Returns default url for likely.
+     * It could be href from <link rel='canonical'>
+     * if presents in the document, or the current url of the page otherwise
+     *
+     * @returns {String}
+     */
+    getDefaultUrl: function () {
+        var link = document.querySelector('link[rel="canonical"]');
+
+        if (link) {
+            return link.href;
+        }
+        return window.location.href.replace(window.location.hash, '');
+    },
 };
 
 module.exports = utils;

--- a/test/test.html
+++ b/test/test.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <title>Likely test page</title>
     <link rel="stylesheet" href="../release/likely.css"/>
+    <link rel="canonical" href="http://ilyabirman.ru/"/>
     <script src="../release/likely.js"></script>
     <style>
         body {
@@ -32,7 +33,7 @@
     <br/>
     <br/>
 
-    <div class="likely" data-url="http://ilyabirman.ru/">
+    <div class="likely">
         <div class="twitter" data-via="ilyabirman">Tweet</div>
         <div class="facebook">Share</div>
         <div class="gplus">+1</div>


### PR DESCRIPTION
Support for rel=canonical url.

Likely constructor already has an ability to specify another url in options, it's used if data-url is absent. I added a new method to utils `getCanonicalUrl`, it returns the url if link[rel=canonical] is in the document.

Also the code:

```js
utils.toArray(widgets)
    .forEach(likely);
```

doesn't work as expected 'cause likely function get 2s arguments: node and its index, and it's not the likely function expects — it should be node and options. Without adding canonical url the error couldn't be revealed.