### PR TITLE
Specify proper dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   },
   "devDependencies": {
     "eslint": "^2.9.0",
-    "gulp": "*",
-    "gulp-browserify": "*",
+    "gulp": "^3.9.1",
+    "gulp-browserify": "^0.5.1",
     "gulp-csso": "^1.0.0",
-    "gulp-insert": "*",
-    "gulp-stylus": "~1.3.4",
-    "gulp-uglify": "~1.0.2",
+    "gulp-insert": "^0.5.0",
+    "gulp-stylus": "^1.3.7",
+    "gulp-uglify": "^1.0.2",
     "gulp-zip": "^2.0.2"
   }
 }


### PR DESCRIPTION
Following #31.

Our `package.json` didn’t specify proper version ranges for `gulp`, `gulp-browserify` and `gulp-insert` which would have broken Likely once a new major version of these packages was released. I specified safe semver ranges for them and updated ranges for `gulp-stylus` and `gulp-uglify` to use `^` instead of `~`.