### PR TITLE
There’s no need for quotes

### DIFF
--- a/styles/likely.styl
+++ b/styles/likely.styl
@@ -8,7 +8,7 @@
   text-indent: 0 !important;
   list-style: none !important;
   font-weight: normal;
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-family: Helvetica Neue, Arial, sans-serif;
   font-size: inherit;
 }
 


### PR DESCRIPTION
It makes list more readable (since there are no quotes around Arial) and saves 2 bytes in resulted CSS. See https://mathiasbynens.be/notes/unquoted-font-family for details.