### PR TITLE
Add the development build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bower_components/*
 npm-debug.log
 bg/*
 release/*.zip
+release/*.map
 
 # JetBrains
 .idea

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 'use strict';
 
 var gulp = require('gulp');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,3 @@
-// "autoprefixer-core": "^4.0.0",
-// "gulp-postcss": "^3.0.0",
-// "gulp-sass": "^1.1.0",
-// "postcss-assets": "^0.9.0"
-
 'use strict';
 
 var gulp = require('gulp');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var gulp = require('gulp');
-var insert = require('gulp-insert');
 var stylus = require('gulp-stylus');
 var csso = require('gulp-csso');
 var zip = require('gulp-zip');
@@ -12,21 +11,9 @@ var webpackConfig = require('./webpack.config.js');
 
 var release = './release/';
 
-function comment(version) {
-    return [
-        '//! Likely $version by Ilya Birman (ilyabirman.net)',
-        '//! Rewritten sans jQuery by Evgeny Steblinsky (volter9.github.io)',
-        '//! Supported by Ivan Akulov (iamakulov.com), Viktor Karpov (vitkarpov.com), and contributors',
-        '//! Inspired by Social Likes by Artem Sapegin (sapegin.me)',
-    ].join('\n').replace(/\$version/g, version);
-}
-
 gulp.task('js', function () {
-    var version = packageJson.version;
-
     return gulp.src('./source/likely.js')
         .pipe(webpack(webpackConfig))
-        .pipe(insert.prepend(comment(version) + '\n'))
         .pipe(gulp.dest(release));
 });
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "eslint": "^2.9.0",
     "gulp": "^3.9.1",
     "gulp-csso": "^1.0.0",
-    "gulp-insert": "^0.5.0",
     "gulp-stylus": "^1.3.7",
     "gulp-zip": "^2.0.2",
     "webpack-stream": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "release/likely-commonjs.js",
   "scripts": {
     "build": "gulp build",
+    "zip": "gulp zip",
     "test": "npm run-script check-codestyle",
     "check-codestyle": "eslint ./",
     "fix-codestyle": "eslint ./ --fix"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "release/likely-commonjs.js",
   "scripts": {
     "build": "gulp build",
+    "dev": "gulp dev",
     "zip": "gulp zip",
     "test": "npm run-script check-codestyle",
     "check-codestyle": "eslint ./",
@@ -20,6 +21,7 @@
     "eslint": "^2.9.0",
     "gulp": "^3.9.1",
     "gulp-csso": "^1.0.0",
+    "gulp-env": "^0.4.0",
     "gulp-stylus": "^1.3.7",
     "gulp-zip": "^2.0.2",
     "webpack-stream": "^3.2.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,11 @@
+/* eslint-env node */
+
 'use strict';
 
 var webpack = require('webpack');
 var packageJson = require('./package.json');
+
+var isProduction = process.env.NODE_ENV === 'production';
 
 function getLicenseComment(version) {
     return [
@@ -23,7 +27,9 @@ module.exports = {
         library: 'likely',
         libraryTarget: 'umd',
     },
-    plugins: [
+    devtool: isProduction ? 'eval' : 'source-map',
+    watch: !isProduction,
+    plugins: isProduction ? [
         new webpack.optimize.OccurrenceOrderPlugin(),
         new webpack.optimize.DedupePlugin(),
         new webpack.optimize.UglifyJsPlugin({
@@ -32,6 +38,6 @@ module.exports = {
                 screw_ie8: true,
             },
         }),
-        new webpack.BannerPlugin(getLicenseComment(packageJson.version))
-    ],
+        new webpack.BannerPlugin(getLicenseComment(packageJson.version)),
+    ] : [],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,16 @@
 'use strict';
 
 var webpack = require('webpack');
+var packageJson = require('./package.json');
+
+function getLicenseComment(version) {
+    return [
+        'Likely $version by Ilya Birman (ilyabirman.net)',
+        'Rewritten sans jQuery by Evgeny Steblinsky (volter9.github.io)',
+        'Supported by Ivan Akulov (iamakulov.com), Viktor Karpov (vitkarpov.com), and contributors',
+        'Inspired by Social Likes by Artem Sapegin (sapegin.me)',
+    ].join('\n').replace(/\$version/g, version);
+}
 
 module.exports = {
     entry: {
@@ -22,5 +32,6 @@ module.exports = {
                 screw_ie8: true,
             },
         }),
+        new webpack.BannerPlugin(getLicenseComment(packageJson.version))
     ],
 };


### PR DESCRIPTION
This PR brings infrastructure improvements that simplify developing Likely.

More precisely, this PR:
* Adds a new `npm run dev` task which builds Likely in development mode (without minification and optimizations + with source maps) and starts watching the code for changes.
* Adds a new `npm run zip` task which can be used to build and zip Likely into a zip archive (previously, there was only `gulp zip` for this).
* Removes watching from the `default` gulp task (now it’s equivalent to `npm run zip`).
* Performs a slight code cleanup.