### PR TITLE
Disable ESLint’s `linebreak-style` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,10 +56,7 @@ module.exports = {
                 "before": true
             }
         ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
+        "linebreak-style": "off",
         "lines-around-comment": "off",
         "max-depth": "error",
         "max-len": "off",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Previously, we enabled this rule to enforce a single format of line endings in the repo. However, the rule causes a lot of unnecessary style errors on Windows. This PR turns the rule off and makes use of `.gitattributes` for the same effect.