### PR TITLE
Likely.initiate breaks counters of existing widgets

### DIFF
--- a/source/widget.js
+++ b/source/widget.js
@@ -62,7 +62,7 @@ Likely.prototype = {
     update: function (options) {
         if (
             options.forceUpdate ||
-            options.url !== this.options.url
+            options.url && options.url !== this.options.url
         ) {
             this.countersLeft = this.buttons.length;
             this.number = 0;


### PR DESCRIPTION
If options for update method are not specified, it will be empty object. [`{}.url` never equals `this.options.url`](https://github.com/ilyabirman/Likely/blob/master/source/widget.js#L65), so the buttons try to reinit.

What happens next? Counters are being updated, and call [the fetch method](https://github.com/ilyabirman/Likely/blob/master/source/fetch.js#L25), which doesn't do anything if there's a corresponding counter and there's no force update. So the counters vanish.