### PR TITLE
Deprecate likely()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -178,7 +178,7 @@ module.exports = {
         "prefer-const": "error",
         "prefer-reflect": "off",
         "prefer-rest-params": "off",
-        "prefer-spread": "error",
+        "prefer-spread": "off",
         "prefer-template": "off",
         "quote-props": [
             "error",

--- a/source/index.js
+++ b/source/index.js
@@ -8,9 +8,10 @@ var dom = require('./dom');
 /**
  * @param {Node} node
  * @param {Object} options
+ * @private
  * @returns {Likely}
  */
-var likely = function (node, options) {
+var initWidget = function (node, options) {
     var fullOptions = options || {};
     var defaults = {
         counters: true,
@@ -36,15 +37,43 @@ var likely = function (node, options) {
 };
 
 /**
+ * @deprecated
+ * @returns {Likely}
+ */
+var likely = function () {
+    // eslint-disable-next-line no-console
+    console.warn('likely function is DEPRECATED and will be removed in 3.0. Use likely.initiate instead.');
+    return likely.initiate.apply(likely, arguments);
+};
+
+/**
  * Initiate Likely buttons on load
+ * @param {Node|Array<Node>|Object} [node] a particular node or an array of widgets,
+ *                                     if not specified,
+ *                                     tries to init all the widgets
  * @param {Object} [options] additional options for each widget
  */
-likely.initiate = likely.initate = function (options) {
-    var widgets = dom.findAll('.' + config.name);
+likely.initiate = likely.initate = function (node, options) {
+    // There're three different ways:
+    // - node is a node
+    // - node is an array of nodes
+    // - node is not a node, it's options (polymorphism)
+    var nodes;
 
-    utils.toArray(widgets)
-        .forEach(function (widget) {
-            likely(widget, options);
+    if (Array.isArray(node)) {
+        nodes = node;
+    }
+    else if (node instanceof Node) {
+        nodes = [node];
+    }
+    else {
+        nodes = dom.findAll('.' + config.name);
+        // eslint-disable-next-line no-param-reassign
+        options = node;
+    }
+    utils.toArray(nodes)
+        .forEach(function (node) {
+            initWidget(node, options);
         });
 };
 


### PR DESCRIPTION
- likely -> initWidget, which is private now
- likely works as expected, but warns user about itself deprecation
- likely.initiate can accept node and options, or just options as expected