### PR TITLE
Switch to Chrome in the UI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
+dist: trusty
 sudo: false
+group: beta
 language: node_js
 node_js:
   - "node"
 addons:
-  firefox: "49.0"
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
 
 before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
+    "chromedriver": "^2.25.1",
     "eslint": "^2.9.0",
     "geckodriver": "^1.1.3",
     "gulp": "^3.9.1",

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
-require('geckodriver');
+require('chromedriver');
 const selenium = require('selenium-webdriver');
 const until = require('selenium-webdriver/lib/until');
 
@@ -26,7 +26,7 @@ describe('Likely', function () {
 
     before(function () {
         driver = new selenium.Builder()
-            .forBrowser('firefox')
+            .forBrowser('chrome')
             .build();
 
         new StaticServer({


### PR DESCRIPTION
Previously, we were using Firefox because it was installed on Travis by default, and because using it allowed us to use [the container-based infrastructure](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments) (which makes the builds much faster).

Turns out Firefox (geckodriver) is too unstable: we’ve already had to write a workaround for a complicated issue (41e5df66dc6a2019e8ea920075c1a3ffbdcb9876), and I got struggles with another one while working on #100. I discovered a way to install Chrome on the container-based infrastructure, so let’s switch to it.