### PR TITLE
Simplify travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: trusty
 sudo: false
-group: beta
 language: node_js
 node_js:
   - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ addons:
     packages:
       - google-chrome-stable
 
-before_install:
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
-
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start &


### PR DESCRIPTION
`group: beta` is [from docs](https://docs.travis-ci.com/user/trusty-ci-environment), but it’s absent [in the announcing blog post](https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/), and seems like removing it affects nothing.

`before_install` isn’t necessary because it does approximately the same as `before_script`.