### PR TITLE
Fix repeated `likely.initiate()` not taking updated options into account

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "chai-as-promised": "^5.3.0",
     "chromedriver": "^2.25.1",
     "eslint": "^2.9.0",
-    "geckodriver": "^1.1.3",
     "gulp": "^3.9.1",
     "gulp-csso": "^1.0.0",
     "gulp-env": "^0.4.0",

--- a/source/index.js
+++ b/source/index.js
@@ -23,14 +23,12 @@ const initWidget = (node, options) => {
     };
     const widget = node[config.name];
 
+    const realOptions = merge({}, defaults, fullOptions, bools(node));
     if (widget) {
-        widget.update(fullOptions);
+        widget.update(realOptions);
     }
     else {
-        node[config.name] = new Likely(node, merge(
-            {}, defaults,
-            fullOptions, bools(node)
-        ));
+        node[config.name] = new Likely(node, realOptions);
     }
 
     return widget;

--- a/test/index.js
+++ b/test/index.js
@@ -136,6 +136,48 @@ describe('Likely', function () {
         });
     });
 
+    describe('changing configuration after being initialized', function () {
+        beforeEach(function () {
+            return getLikelyPage(driver, LikelyPage.AUTOINIT)
+                .then(() => waitUntilLikelyInitialized(driver));
+        });
+
+        it('should change the shared URL when the new options are passed as a JS object', function () {
+            return driver.executeScript(`
+                likely.initiate({
+                    url: 'http://google.com'
+                });
+            `)
+                .then(function () {
+                    return expectClickToOpen(driver, '.likely__widget_twitter', /twitter\.com\/.*google\.com/);
+                });
+        });
+
+        it('should change the shared URL when the new URL is specified on the node', function () {
+            return driver.executeScript(`
+                document.querySelector('.likely').setAttribute('data-url', 'http://google.com');
+                likely.initiate();
+            `)
+                .then(function () {
+                    return expectClickToOpen(driver, '.likely__widget_twitter', /twitter\.com\/.*google\.com/);
+                });
+        });
+
+        it('should change the shared URL when the new URL is specified as <link rel="canonical">', function () {
+            return driver.executeScript(`
+                const link = document.createElement('link');
+                link.setAttribute('rel', 'canonical');
+                link.setAttribute('href', 'http://google.com');
+                document.head.appendChild(link);
+                
+                likely.initiate();
+            `)
+                .then(function () {
+                    return expectClickToOpen(driver, '.likely__widget_twitter', /twitter\.com\/.*google\.com/);
+                });
+        });
+    });
+
     describe('fetching counters', function () {
         before(function () {
             return getLikelyPage(driver, LikelyPage.AUTOINIT)


### PR DESCRIPTION
Closes #90. Includes tests.

Also, includes some minor clean-up after #103.