### PR TITLE
[#112] Ошибка в ИЕ11

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-preset-latest": "^6.16.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
-    "chromedriver": "^2.25.1",
+    "chromedriver": "~2.25.1",
     "eslint": "^2.9.0",
     "gulp": "^3.9.1",
     "gulp-csso": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-preset-latest": "^6.16.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
-    "chromedriver": "~2.25.1",
+    "chromedriver": "^2.25.1",
     "eslint": "^2.9.0",
     "gulp": "^3.9.1",
     "gulp-csso": "^1.0.0",

--- a/source/dom.js
+++ b/source/dom.js
@@ -76,7 +76,7 @@ export const find = (selector, node) => (node || document).querySelector(selecto
  * @param {Node} [node]
  * @returns {Node[]}
  */
-export const findAll = (selector, node) => [...(node || document).querySelectorAll(selector)];
+export const findAll = (selector, node) => Array.prototype.slice.call((node || document).querySelectorAll(selector));
 /**
  * Open the popup
  *

--- a/source/utils.js
+++ b/source/utils.js
@@ -23,17 +23,17 @@ export const each = (object, callback) => {
 export const toArray = (arrayLike) => Array.prototype.slice.call(arrayLike);
 
 /**
- * Merge given dictionaries (objects) into one object
+ * Merge given dictionaries (objects) into one object.
+ * Iterates across the arguments.
  *
- * @param {...Object} object
  * @returns {Object}
  */
-export const merge = (...args) => { // eslint-disable-line no-unused-vars
+export const merge = function () {
     const result = {};
-    const argsArr = [...args];
+    const args = Array.prototype.slice.call(arguments); // eslint-disable-line no-undef
 
-    for (let i = 0; i < argsArr.length; i++) {
-        const arg = argsArr[i];
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
 
         if (arg) {
             for (const key in arg) {


### PR DESCRIPTION
IE11 doesn't know about Array.from. Babel implicitly makes a polyfill for spread operator within arrays, and we end up using Array.from.
See more about it https://github.com/babel/babel/issues/4922