### PR TITLE
Fix the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ node_js:
   - "node"
 addons:
   apt:
-    sources:
-      - google-chrome
     packages:
       - google-chrome-stable
 

--- a/source/index.js
+++ b/source/index.js
@@ -1,9 +1,13 @@
-import { bools, getDefaultUrl, merge } from './utils';
+// This module is an entry point for CommonJS modules.
+// It’s written with CommonJS imports and exports to make possible doing `module.exports = likely`.
+// This is required so that users work with `require('likely')`, not `require('likely').default`
 
-import Likely from './widget';
-import config from './config';
-import { findAll } from './dom';
-import history from './history';
+const { bools, getDefaultUrl, merge } = require('./utils');
+
+const Likely = require('./widget').default;
+const config = require('./config').default;
+const { findAll } = require('./dom');
+const history = require('./history').default;
 
 /**
  * @param {Node} node
@@ -89,6 +93,4 @@ class likely {
     }
 }
 
-// `module.exports` instead of `export default`:
-// public API should be `likely.initiate`, not `likely.default.initiate`
 module.exports = likely;

--- a/source/likely.js
+++ b/source/likely.js
@@ -1,9 +1,11 @@
-import likely from './index.js';
+// This module is an entry point when `likely.js` is just dropped into the browser.
+// It’s written with CommonJS imports and exports to make possible doing `module.exports = likely`.
+// This is required so that users work with `window.likely`, not `window.likely.default`
+
+const likely = require('./index.js');
 
 window.addEventListener('load', () => {
     likely.initiate();
 });
 
-// `module.exports` instead of `export default`:
-// public API should be `likely.initiate`, not `likely.default.initiate`
 module.exports = likely;

--- a/test/utils/expectClickToOpen.js
+++ b/test/utils/expectClickToOpen.js
@@ -26,12 +26,12 @@ function expectClickToOpen(driver, clickTarget, windowUrlRegex) {
             driver.getAllWindowHandles(),
         ]))
         .then(([currentHandle, handles]) => {
-            console.debug('originalWindowHandle', originalWindowHandle);
-            console.debug('handles', handles);
+            console.log('originalWindowHandle', originalWindowHandle);
+            console.log('handles', handles);
             originalWindowHandle = currentHandle;
 
             const newWindowHandle = handles.find((handle) => handle !== currentHandle);
-            console.debug('newWindowHandle', newWindowHandle);
+            console.log('newWindowHandle', newWindowHandle);
             return driver.switchTo().window(newWindowHandle);
         })
         // `driver.wait()` is used because Firefox opens a new window with `about:blank' initially
@@ -52,8 +52,8 @@ function expectClickToOpen(driver, clickTarget, windowUrlRegex) {
         })
         .then(() => {
             return driver.getAllWindowHandles().then((allHandles) => {
-                console.debug('allHandles after closing', allHandles);
-                console.debug('originalWindowHandle after closing', originalWindowHandle);
+                console.log('allHandles after closing', allHandles);
+                console.log('originalWindowHandle after closing', originalWindowHandle);
                 return driver.switchTo().window(originalWindowHandle);
             });
         })

--- a/test/utils/expectClickToOpen.js
+++ b/test/utils/expectClickToOpen.js
@@ -21,8 +21,9 @@ function expectClickToOpen(driver, clickTarget, windowUrlRegex) {
     const realClickTarget = typeof clickTarget === 'string' ? driver.findElement({ css: clickTarget }) : clickTarget;
 
     return realClickTarget.click()
+        // Set a timeout to wait until the new window opens. This prevents random crashes in Travis
         .then(() => {
-            return new Promise(resolve => setTimeout(resolve, 500))
+            return new Promise((resolve) => setTimeout(resolve, 200));
         })
         .then(() => Promise.all([
             driver.getWindowHandle(),
@@ -30,11 +31,8 @@ function expectClickToOpen(driver, clickTarget, windowUrlRegex) {
         ]))
         .then(([currentHandle, handles]) => {
             originalWindowHandle = currentHandle;
-            console.log('originalWindowHandle', originalWindowHandle);
-            console.log('handles', handles);
 
             const newWindowHandle = handles.find((handle) => handle !== currentHandle);
-            console.log('newWindowHandle', newWindowHandle);
             return driver.switchTo().window(newWindowHandle);
         })
         // `driver.wait()` is used because Firefox opens a new window with `about:blank' initially
@@ -54,11 +52,7 @@ function expectClickToOpen(driver, clickTarget, windowUrlRegex) {
             return driver.close();
         })
         .then(() => {
-            return driver.getAllWindowHandles().then((allHandles) => {
-                console.log('allHandles after closing', allHandles);
-                console.log('originalWindowHandle after closing', originalWindowHandle);
-                return driver.switchTo().window(originalWindowHandle);
-            });
+            return driver.switchTo().window(originalWindowHandle);
         })
         // We compare the URLs only after closing the dialog and switching back to the main window.
         // If we do it before and the comparison fails, all the `.then()` branches won’t execute,

--- a/test/utils/expectClickToOpen.js
+++ b/test/utils/expectClickToOpen.js
@@ -21,14 +21,17 @@ function expectClickToOpen(driver, clickTarget, windowUrlRegex) {
     const realClickTarget = typeof clickTarget === 'string' ? driver.findElement({ css: clickTarget }) : clickTarget;
 
     return realClickTarget.click()
+        .then(() => {
+            return new Promise(resolve => setTimeout(resolve, 500))
+        })
         .then(() => Promise.all([
             driver.getWindowHandle(),
             driver.getAllWindowHandles(),
         ]))
         .then(([currentHandle, handles]) => {
+            originalWindowHandle = currentHandle;
             console.log('originalWindowHandle', originalWindowHandle);
             console.log('handles', handles);
-            originalWindowHandle = currentHandle;
 
             const newWindowHandle = handles.find((handle) => handle !== currentHandle);
             console.log('newWindowHandle', newWindowHandle);

--- a/test/utils/expectClickToOpen.js
+++ b/test/utils/expectClickToOpen.js
@@ -26,9 +26,12 @@ function expectClickToOpen(driver, clickTarget, windowUrlRegex) {
             driver.getAllWindowHandles(),
         ]))
         .then(([currentHandle, handles]) => {
+            console.debug('originalWindowHandle', originalWindowHandle);
+            console.debug('handles', handles);
             originalWindowHandle = currentHandle;
 
             const newWindowHandle = handles.find((handle) => handle !== currentHandle);
+            console.debug('newWindowHandle', newWindowHandle);
             return driver.switchTo().window(newWindowHandle);
         })
         // `driver.wait()` is used because Firefox opens a new window with `about:blank' initially
@@ -48,7 +51,11 @@ function expectClickToOpen(driver, clickTarget, windowUrlRegex) {
             return driver.close();
         })
         .then(() => {
-            return driver.switchTo().window(originalWindowHandle);
+            return driver.getAllWindowHandles().then((allHandles) => {
+                console.debug('allHandles after closing', allHandles);
+                console.debug('originalWindowHandle after closing', originalWindowHandle);
+                return driver.switchTo().window(originalWindowHandle);
+            });
         })
         // We compare the URLs only after closing the dialog and switching back to the main window.
         // If we do it before and the comparison fails, all the `.then()` branches won’t execute,

--- a/test/utils/expectClickToOpen.js
+++ b/test/utils/expectClickToOpen.js
@@ -14,7 +14,6 @@ const until = require('selenium-webdriver/lib/until');
  * @returns {Promise.<undefined>} Promise that resolves when the
  */
 function expectClickToOpen(driver, clickTarget, windowUrlRegex) {
-    let originalWindowHandle;
     let openedUrl;
 
     // clickTarget can be either a selector or a node
@@ -30,8 +29,6 @@ function expectClickToOpen(driver, clickTarget, windowUrlRegex) {
             driver.getAllWindowHandles(),
         ]))
         .then(([currentHandle, handles]) => {
-            originalWindowHandle = currentHandle;
-
             const newWindowHandle = handles.find((handle) => handle !== currentHandle);
             return driver.switchTo().window(newWindowHandle);
         })
@@ -51,8 +48,9 @@ function expectClickToOpen(driver, clickTarget, windowUrlRegex) {
 
             return driver.close();
         })
-        .then(() => {
-            return driver.switchTo().window(originalWindowHandle);
+        .then(() => driver.getAllWindowHandles())
+        .then(([primaryWindowHandle]) => {
+            return driver.switchTo().window(primaryWindowHandle);
         })
         // We compare the URLs only after closing the dialog and switching back to the main window.
         // If we do it before and the comparison fails, all the `.then()` branches won’t execute,


### PR DESCRIPTION
597def6: seems like `google-chrome` is already included into default sources. Removed it to prevent producing the warnings.

e225f9d: there was a change somewhere around `webpack@2.2.0-rc.1` that made it impossible to use CommonJS imports/exports simultaneously with ES ones in one file. This caused the runtime error which prevented Likely from initializing.