### PR TITLE
Set files field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
     "//": "`in-publish` is used so that the CI doesn’t run tests during the installation. If it does and the tests fail, the build gets errored instead of failed.",
     "prepublish": "in-publish && npm run test || not-in-publish"
   },
+  "files": [
+    "source",
+    "styles",
+    "release",
+    "license.txt"
+  ],
   "devDependencies": {
     "babel-core": "^6.18.2",
     "babel-loader": "^6.2.7",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
     "prepublish": "in-publish && npm run test || not-in-publish"
   },
   "files": [
-    "source",
-    "styles",
     "release",
     "license.txt"
   ],


### PR DESCRIPTION
Publish only files we needed via `files` field in `package.json`. Now in npm published dev stuff too, what causes build error in my project (`.babelrc`).